### PR TITLE
Fix loading hint image css

### DIFF
--- a/client/src/components/loading/LoadingPage.scss
+++ b/client/src/components/loading/LoadingPage.scss
@@ -87,6 +87,8 @@
     
     .loading-hint-image {
         height: 100%;
+        width: 100%;
+        object-fit: contain;
     }
       
     .loading-hint-text {


### PR DESCRIPTION
This fixes the following issue:
In Firefox (and potentially other browsers), the loading hint image pushes around the text, sometimes even causing it to go off-screen. 

[Before](https://media1.giphy.com/media/2j8HqteTV4qNyus6MM/giphy.gif?cid=790b761153585dae7c63fc8956e7a0c5c4dd34334f0731ab&rid=giphy.gif&ct=g)

[After](https://media2.giphy.com/media/sesB7NpXDqmhjlLjCf/giphy.gif?cid=790b76112a784b07c878f14386ee24c231a2828bfbe0d377&rid=giphy.gif&ct=g)