### PR TITLE
Make priests heal nearby players who aren't in combat

### DIFF
--- a/server/src/entities/classes/destroyables/movables/characters/mobs/merchants/PriestMerchant.js
+++ b/server/src/entities/classes/destroyables/movables/characters/mobs/merchants/PriestMerchant.js
@@ -5,7 +5,7 @@ const Heal = require("../../../../../../../gameplay/Heal");
 class PriestMerchant extends Merchant {
     constructor(config) {
         super(config);
-        // Heal nearby players every 4 seconds
+        // Heal nearby players every 2 seconds
         this.healInterval = setInterval(this.healNearbyPlayers.bind(this), 2000);
     }
 


### PR DESCRIPTION
Meets first criterion of #163 :
_Priest mobs should be made to automatically heal all players that are not in combat in an area around themselves once every interval. (area and interval values to be determined while testing)._

Starting values:
Interval: 2 seconds
Area: 2 tiles
Heal Amount: 5